### PR TITLE
Fix for Bullseye new KMS path

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -67,7 +67,7 @@ Open a terminal and run ``rpi-backlight``.
     20
     $ rpi-backlight --get-power
     on
-    $ rpi-backlight --p off
+    $ rpi-backlight -p off
     $ rpi-backlight --get-power
     off
     $ rpi-backlight --set-power off :emulator:

--- a/rpi_backlight/__init__.py
+++ b/rpi_backlight/__init__.py
@@ -2,9 +2,8 @@ import errno
 import time
 from contextlib import contextmanager
 from enum import Enum
-from os import PathLike, listdir, path
+from os import PathLike
 from pathlib import Path
-from genericpath import exists
 from tempfile import gettempdir
 from typing import Generator, Union, Optional
 
@@ -24,12 +23,15 @@ class BoardType(Enum):
     TINKER_BOARD = 2
     #: Tinker Board 2
     TINKER_BOARD_2 = 3
+    #: Raspberry Pi using KMS drivers
+    RASPBERRY_PI_KMS = 4
 
 
 _BACKLIGHT_SYSFS_PATHS = {
     BoardType.RASPBERRY_PI: "/sys/class/backlight/rpi_backlight/",
     BoardType.TINKER_BOARD: "/sys/devices/platform/ff150000.i2c/i2c-3/3-0045/",
     BoardType.TINKER_BOARD_2: "/sys/devices/platform/ff3e0000.i2c/i2c-8/8-0045/",
+    BoardType.RASPBERRY_PI_KMS: "/sys/class/backlight/10-0045/",
 }
 _EMULATOR_SYSFS_TMP_FILE_PATH = Path(gettempdir()) / "rpi-backlight-emulator.sysfs"
 _EMULATOR_MAGIC_STRING = ":emulator:"
@@ -68,16 +70,14 @@ class Backlight:
             # (brightness, bl_power), ignore board_type
             board_type = BoardType.RASPBERRY_PI
         
-        # Fix for Bullseye new KMS path
-        if board_type == BoardType.RASPBERRY_PI and not exists(backlight_sysfs_path):
-            backlight_sysfs_path_fix = '/'.join([l for i, l in enumerate(backlight_sysfs_path.split('/')) if i < 4])
-            backlight_sysfs_path = backlight_sysfs_path_fix + '/' + listdir(backlight_sysfs_path_fix)[0] + '/'
-
         self._backlight_sysfs_path = Path(backlight_sysfs_path)
         self._board_type = board_type
         self._fade_duration = 0.0  # in seconds
 
-        if self._board_type == BoardType.RASPBERRY_PI:
+        if (
+            self._board_type == BoardType.RASPBERRY_PI
+            or self._board_type == BoardType.RASPBERRY_PI_KMS
+        ):
             self._max_brightness = self._get_value("max_brightness")  # 255
         elif (
             self._board_type == BoardType.TINKER_BOARD
@@ -166,7 +166,10 @@ class Backlight:
         :setter: Set the display brightness.
         :type: float
         """
-        if self._board_type == BoardType.RASPBERRY_PI:
+        if (
+            self._board_type == BoardType.RASPBERRY_PI
+            or self._board_type == BoardType.RASPBERRY_PI_KMS
+        ):
             return self._normalize_brightness(self._get_value("actual_brightness"))
         elif (
             self._board_type == BoardType.TINKER_BOARD
@@ -194,7 +197,10 @@ class Backlight:
                 and current_value <= 100.0
             ):
                 current_value += step
-                if self._board_type == BoardType.RASPBERRY_PI:
+                if (
+                    self._board_type == BoardType.RASPBERRY_PI
+                    or self._board_type == BoardType.RASPBERRY_PI_KMS
+                ):
                     self._set_value(
                         "brightness", self._denormalize_brightness(current_value)
                     )
@@ -209,7 +215,10 @@ class Backlight:
                     raise RuntimeError("Invalid board type")
                 time.sleep(self.fade_duration / diff)
         else:
-            if self._board_type == BoardType.RASPBERRY_PI:
+            if (
+                self._board_type == BoardType.RASPBERRY_PI
+                or self._board_type == BoardType.RASPBERRY_PI_KMS
+            ):
                 self._set_value("brightness", self._denormalize_brightness(value))
             elif (
                 self._board_type == BoardType.TINKER_BOARD
@@ -232,7 +241,10 @@ class Backlight:
         :setter: Set the display power on or off.
         :type: bool
         """
-        if self._board_type == BoardType.RASPBERRY_PI:
+        if (
+            self._board_type == BoardType.RASPBERRY_PI
+            or self._board_type == BoardType.RASPBERRY_PI_KMS
+        ):
             # 0 is on, 1 is off
             return not self._get_value("bl_power")
         elif (
@@ -248,7 +260,10 @@ class Backlight:
         """Set the display power on or off."""
         if not isinstance(on, bool):
             raise TypeError(f"value must be a bool, got {type(on)}")
-        if self._board_type == BoardType.RASPBERRY_PI:
+        if (
+            self._board_type == BoardType.RASPBERRY_PI
+            or self._board_type == BoardType.RASPBERRY_PI_KMS
+        ):
             # 0 is on, 1 is off
             self._set_value("bl_power", int(not on))
         elif (

--- a/rpi_backlight/__init__.py
+++ b/rpi_backlight/__init__.py
@@ -2,8 +2,9 @@ import errno
 import time
 from contextlib import contextmanager
 from enum import Enum
-from os import PathLike
+from os import PathLike, listdir, path
 from pathlib import Path
+from genericpath import exists
 from tempfile import gettempdir
 from typing import Generator, Union, Optional
 
@@ -66,6 +67,11 @@ class Backlight:
             # The emulator only knows about Raspberry Pi sysfs files
             # (brightness, bl_power), ignore board_type
             board_type = BoardType.RASPBERRY_PI
+        
+        # Fix for Bullseye new KMS path
+        if board_type == BoardType.RASPBERRY_PI and not exists(backlight_sysfs_path):
+            backlight_sysfs_path_fix = '/'.join([l for i, l in enumerate(backlight_sysfs_path.split('/')) if i < 4])
+            backlight_sysfs_path = backlight_sysfs_path_fix + '/' + listdir(backlight_sysfs_path_fix)[0] + '/'
 
         self._backlight_sysfs_path = Path(backlight_sysfs_path)
         self._board_type = board_type

--- a/rpi_backlight/cli.py
+++ b/rpi_backlight/cli.py
@@ -6,12 +6,14 @@ STRING_TO_BOARD_TYPE = {
     "raspberry-pi": BoardType.RASPBERRY_PI,
     "tinker-board": BoardType.TINKER_BOARD,
     "tinker-board-2": BoardType.TINKER_BOARD_2,
+    "raspberry-pi-kms": BoardType.RASPBERRY_PI_KMS,
 }
 
 BOARD_TYPE_TO_STRING = {
     BoardType.RASPBERRY_PI: "raspberry-pi",
     BoardType.TINKER_BOARD: "tinker-board",
     BoardType.TINKER_BOARD_2: "tinker-board-2",
+    BoardType.RASPBERRY_PI_KMS: "raspberry-pi-kms",
 }
 
 

--- a/rpi_backlight/utils.py
+++ b/rpi_backlight/utils.py
@@ -16,6 +16,8 @@ def detect_board_type() -> Optional["BoardType"]:
     from . import BoardType
 
     model_file = Path("/proc/device-tree/model")
+    driver_file = Path("/proc/device-tree/soc/hvs@7e400000/status")
+    
     try:
         model = model_file.read_text()
     except OSError:
@@ -28,7 +30,11 @@ def detect_board_type() -> Optional["BoardType"]:
         return BoardType.TINKER_BOARD
     # Raspberry Pi starts with Raspberry Pi
     elif "Raspberry Pi" in model:
-        return BoardType.RASPBERRY_PI
+        # Raspberry Pi with KMS Driver returns okay
+        if "okay" in driver_file.read_text():
+            return BoardType.RASPBERRY_PI_KMS
+        else:
+            return BoardType.RASPBERRY_PI
     else:
         return None
 


### PR DESCRIPTION
The path to the backlight is now /sys/class/backlight/10-0045/brightness due to the swap to KMS in Bullseye, which resulted in a file not found error when executing a command.

This is a quick and dirty fix to dynamically fix the control path.

