### PR TITLE
Support alternate backlight sysfs path

### DIFF
--- a/rpi_backlight/__init__.py
+++ b/rpi_backlight/__init__.py
@@ -26,7 +26,11 @@ class BoardType(Enum):
 
 
 _BACKLIGHT_SYSFS_PATHS = {
-    BoardType.RASPBERRY_PI: "/sys/class/backlight/rpi_backlight/",
+    BoardType.RASPBERRY_PI: (
+        "/sys/class/backlight/10-0045/"
+        if Path("/sys/class/backlight/10-0045/").exists()
+        else "/sys/class/backlight/rpi_backlight/"
+    ),
     BoardType.TINKER_BOARD: "/sys/devices/platform/ff150000.i2c/i2c-3/3-0045/",
     BoardType.TINKER_BOARD_2: "/sys/devices/platform/ff3e0000.i2c/i2c-8/8-0045/",
 }


### PR DESCRIPTION
[Fix for Bullseye new KMS path](https://github.com/linusg/rpi-backlight/pull/48#)
#48