### PR TITLE
Power on with duration, power on if brightness > 0

### DIFF
--- a/rpi_backlight/cli.py
+++ b/rpi_backlight/cli.py
@@ -100,8 +100,12 @@ def main():
                 "-b/--set-brightness must be used without other options except for -d/--duration"
             )
         # backlight.fade context manager can be used always as args.fade defaults to zero
+        if (backlight.power is False) and (args.set_brightness > 0):	
+            backlight.power = True
         with backlight.fade(duration=args.duration):
             backlight.brightness = args.set_brightness
+        if (backlight.power is True) and (args.set_brightness == 0):	
+            backlight.power = False
         return
 
     if args.set_power:
@@ -120,6 +124,18 @@ def main():
                     backlight.power = True
                 with backlight.fade(duration=args.duration):
                     backlight.brightness = 100
+        elif args.set_power == "on": 
+            if backlight.power: 
+                return  
+            backlight.power = True  
+            if args.duration:   
+                with backlight.fade(duration=args.duration):    
+                    backlight.brightness = 100  
+        elif args.set_power == "off":   
+            if args.duration:   
+                with backlight.fade(duration=args.duration):    
+                    backlight.brightness = 0    
+            backlight.power = False
         else:
             backlight.power = True if args.set_power == "on" else False
         return

--- a/rpi_backlight/cli.py
+++ b/rpi_backlight/cli.py
@@ -100,12 +100,8 @@ def main():
                 "-b/--set-brightness must be used without other options except for -d/--duration"
             )
         # backlight.fade context manager can be used always as args.fade defaults to zero
-        if (backlight.power is False) and (args.set_brightness > 0):	
-            backlight.power = True
         with backlight.fade(duration=args.duration):
             backlight.brightness = args.set_brightness
-        if (backlight.power is True) and (args.set_brightness == 0):	
-            backlight.power = False
         return
 
     if args.set_power:
@@ -124,18 +120,6 @@ def main():
                     backlight.power = True
                 with backlight.fade(duration=args.duration):
                     backlight.brightness = 100
-        elif args.set_power == "on": 
-            if backlight.power: 
-                return  
-            backlight.power = True  
-            if args.duration:   
-                with backlight.fade(duration=args.duration):    
-                    backlight.brightness = 100  
-        elif args.set_power == "off":   
-            if args.duration:   
-                with backlight.fade(duration=args.duration):    
-                    backlight.brightness = 0    
-            backlight.power = False
         else:
             backlight.power = True if args.set_power == "on" else False
         return

--- a/rpi_backlight/cli.py
+++ b/rpi_backlight/cli.py
@@ -100,8 +100,12 @@ def main():
                 "-b/--set-brightness must be used without other options except for -d/--duration"
             )
         # backlight.fade context manager can be used always as args.fade defaults to zero
+        if (backlight.power is False) and (args.set_brightness > 0):
+            backlight.power = True
         with backlight.fade(duration=args.duration):
             backlight.brightness = args.set_brightness
+        if (backlight.power is True) and (args.set_brightness == 0):
+            backlight.power = False
         return
 
     if args.set_power:
@@ -120,6 +124,18 @@ def main():
                     backlight.power = True
                 with backlight.fade(duration=args.duration):
                     backlight.brightness = 100
+        elif args.set_power == "on":
+            if backlight.power:
+                return
+            backlight.power = True
+            if args.duration:
+                with backlight.fade(duration=args.duration):
+                    backlight.brightness = 100
+        elif args.set_power == "off":
+            if args.duration:
+                with backlight.fade(duration=args.duration):
+                    backlight.brightness = 0
+            backlight.power = False
         else:
             backlight.power = True if args.set_power == "on" else False
         return


### PR DESCRIPTION
Hi Linus,
On my Pi4, I am able to successfully fade with a duration with `rpi-backlight -b 0 -d 3`. However, I cant power on/off with a duration `rpi-backlight -p off -d 3`. I can, however, toggle with a duration just fine `rpi-backlight -p toggle -d 3` 
I believe we should be able to power on/off with a duration based on this line in the code, showing the intention that power setting may indeed be set with a duration.
`parser.error("-p/--set-power may only be used with -d/--duration")`

After checking the code, I found that powering on/off with a duration wasn't actually implemented yet
So, I added it as a feature:
-Power on/off is now supported with duration

Additionally, I found that if you set the brightness to 100 while the power is off, nothing happens. So, I added an extra 2 features:
-If setting brightness >0, turn the power on first. (This will better the user experience)
-If setting brightness to 0, turn the power off once brightness is 0. (Perhaps $ energy savings?)

I also added a quick check to the code.
-Do not try to power on if already on (This will prevent the brightness from setting to 100 if brightness is already turned up (i.e. 40) and you try to power on) which fixes #44 
