### PR TITLE
Update RP5 on latest os

### DIFF
--- a/rpi_backlight/__init__.py
+++ b/rpi_backlight/__init__.py
@@ -35,6 +35,8 @@ _BACKLIGHT_SYSFS_PATHS = {
         if Path("/sys/class/backlight/6-0045/").exists()
         else "/sys/class/backlight/10-0045/"
         if Path("/sys/class/backlight/10-0045/").exists()
+        else "/sys/class/backlight/11-0045/"
+        if Path("/sys/class/backlight/11-0045/").exists()
         else "/sys/class/backlight/rpi_backlight/"
     ),
     BoardType.TINKER_BOARD: "/sys/devices/platform/ff150000.i2c/i2c-3/3-0045/",


### PR DESCRIPTION
@linusg On my RPI5 with the 11/19 release of bookworm lite 64 a new folder is being used.