### PR TITLE
Power on with duration; power on if brightness > 0; fix backlight device selection on KMS systems; handle multiple backlight sysfs nodes correctly

### DIFF
--- a/rpi_backlight/cli.py
+++ b/rpi_backlight/cli.py
@@ -102,8 +102,12 @@ def main():
                 "-b/--set-brightness must be used without other options except for -d/--duration"
             )
         # backlight.fade context manager can be used always as args.fade defaults to zero
+        if (backlight.power is False) and (args.set_brightness > 0):
+            backlight.power = True
         with backlight.fade(duration=args.duration):
             backlight.brightness = args.set_brightness
+        if (backlight.power is True) and (args.set_brightness == 0):
+            backlight.power = False
         return
 
     if args.set_power:
@@ -122,6 +126,19 @@ def main():
                     backlight.power = True
                 with backlight.fade(duration=args.duration):
                     backlight.brightness = 100
+        elif args.set_power == "on":
+            # Ensure brightness is 0 when we turn the display on
+            backlight.brightness = 0
+            if args.board_type == "raspberry-pi":
+                backlight.power = True
+            with backlight.fade(duration=args.duration):
+                backlight.brightness = 100
+        elif args.set_power == "off":
+            if backlight.power:
+                with backlight.fade(duration=args.duration):
+                    backlight.brightness = 0
+                if args.board_type == "raspberry-pi":
+                    backlight.power = False
         else:
             backlight.power = True if args.set_power == "on" else False
         return


### PR DESCRIPTION
Hi Linus,
On my Pi, I am able to successfully fade with a duration with `rpi-backlight -b 0 -d 3`. However, I cant power on/off with a duration `rpi-backlight -p off -d 3`. I can, however, toggle with a duration just fine `rpi-backlight -p toggle -d 3` 
I believe we should be able to power on/off with a duration based on this line in the code, showing the intention that power setting may indeed be set with a duration.
`parser.error("-p/--set-power may only be used with -d/--duration")`

After checking the code, I found that powering on/off with a duration wasn't actually implemented yet
So, I added it as a feature:
-Power on/off is now supported with duration

Additionally, I found that if you set the brightness to 100 while the power is off, nothing happens. So, I added an extra 2 features:
-If setting brightness >0, turn the power on first. (This will better the user experience)
-If setting brightness to 0, turn the power off once brightness is 0. (Perhaps $ energy savings?)

I also added a quick check to the code.
-Do not try to power on if already on (This will prevent the brightness from setting to 100 if brightness is already turned up (i.e. 40) and you try to power on) which fixes #44 

There is a difference between power and toggle however that needs to be reflected in the code I believe.
If its on, and you try to turn it on, nothing should happen.
If its on, and you try to toggle it, it should turn off.

Toggle does not have this problem, because if you toggle it while its already on, it will just turn off

This code prevents setting the brightness to 100 if lets say, brightness is currently 40 and you power on. Without this code, if you power on an and the screen is already, brightness will just go to 100, which is probably not what the user wanted.